### PR TITLE
feat: correct FHEVMConfig initialization for proxy dApp

### DIFF
--- a/hardhat/contracts/fheWordle/FHEWordle.sol
+++ b/hardhat/contracts/fheWordle/FHEWordle.sol
@@ -66,6 +66,7 @@ contract FHEWordle is SepoliaZamaFHEVMConfig, SepoliaZamaGatewayConfig, GatewayC
     constructor() Ownable(msg.sender) {}
 
     function initialize(address _playerAddr, address _relayerAddr, uint16 _testFlag) external initializer {
+        TFHE.setFHEVM(ZamaFHEVMConfig.getSepoliaConfig());
         relayerAddr = _relayerAddr;
         playerAddr = _playerAddr;
         testFlag = _testFlag;


### PR DESCRIPTION
Note: if this dApp will be only ever used as a clone, you dont even need to inherit the abstract contract config.
Note2: please do the same thing for the gateway setup if any decryption is involved.